### PR TITLE
Add photography page with gallery-style framed photo layout

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import Box from '@mui/material/Box';
 import Generative from './generative/Generative';
 import Header from './header/Header';
 import Resume from './resume/Resume';
+import Photography from './photography/Photography';
 import { colors } from './colors';
 
 function Home() {
@@ -25,6 +26,15 @@ function ResumePage() {
     <Box sx={{ flexGrow: 1, backgroundColor: colors.darkBlue, minHeight: '100vh', width: 1 }}>
       <Header />
       <Resume />
+    </Box>
+  );
+}
+
+function PhotographyPage() {
+  return (
+    <Box sx={{ flexGrow: 1, backgroundColor: colors.white, minHeight: '100vh', width: 1 }}>
+      <Header variant="dark" />
+      <Photography />
     </Box>
   );
 }
@@ -72,6 +82,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/resume" element={<ResumePage />} />
+        <Route path="/photography" element={<PhotographyPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/colors.js
+++ b/src/colors.js
@@ -1,5 +1,6 @@
 export const colors = {
     "black": "#000000",
+    "white": "#FFFFFF",
     "teal": "#A9FBD7",
     "darkBlue": "#00203F",
 }

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -7,16 +7,21 @@ import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
 import GitHub from '@mui/icons-material/GitHub';
 import Assignment from '@mui/icons-material/Assignment';
+import CameraAlt from '@mui/icons-material/CameraAlt';
 import Box from '@mui/material/Box';
 import { LinkedIn } from '@mui/icons-material';
 import { colors } from '../colors';
 
 
 
-function Header() {
+function Header({ variant }) {
+    const isDark = variant === 'dark';
+    const color = isDark ? colors.black : colors.teal;
+    const bg = isDark ? colors.white : colors.darkBlue;
+
     return (
         <AppBar elevation={0} position="fixed" sx={{
-            backgroundColor: colors.darkBlue,
+            backgroundColor: bg,
             '&::after': {
                 content: '""',
                 position: 'absolute',
@@ -25,7 +30,7 @@ function Header() {
                 right: 0,
                 height: '24px',
                 transform: 'translateY(100%)',
-                background: `linear-gradient(to bottom, ${colors.darkBlue}, transparent)`,
+                background: `linear-gradient(to bottom, ${bg}, transparent)`,
                 pointerEvents: 'none',
             },
         }}>
@@ -36,7 +41,7 @@ function Header() {
                     to="/"
                     sx={{
                         flexGrow: 1,
-                        color: colors.teal,
+                        color: color,
                         textDecoration: 'none',
                     }}
                 >
@@ -49,16 +54,26 @@ function Header() {
                     component={RouterLink}
                     to="/resume"
                     aria-label="Resume"
-                    style={{ color: colors.teal }}
+                    style={{ color: color }}
                 >
                     <Assignment />
                 </IconButton>
                 <IconButton
                     size="large"
                     edge="end"
+                    component={RouterLink}
+                    to="/photography"
+                    aria-label="Photography"
+                    style={{ color: color }}
+                >
+                    <CameraAlt />
+                </IconButton>
+                <IconButton
+                    size="large"
+                    edge="end"
                     href="https://www.linkedin.com/in/markspicerjr/"
                     aria-label="LinkedIn Profile"
-                    style={{ color: colors.teal }}
+                    style={{ color: color }}
                 >
                     <LinkedIn />
                 </IconButton>
@@ -67,7 +82,7 @@ function Header() {
                     edge="end"
                     href="https://github.com/betterengineering"
                     aria-label="GitHub Profile"
-                    style={{ color: colors.teal }}
+                    style={{ color: color }}
                 >
                     <GitHub />
                 </IconButton>

--- a/src/photography/Photography.js
+++ b/src/photography/Photography.js
@@ -33,7 +33,7 @@ const captionSx = {
 
 const frameSx = {
     backgroundColor: colors.white,
-    border: `3px solid ${colors.black}`,
+    border: `5px solid ${colors.black}`,
     boxShadow: '6px 6px 20px rgba(0, 0, 0, 0.3), 2px 2px 6px rgba(0, 0, 0, 0.15)',
     // Matte padding: more on bottom like a real gallery matte
     padding: '24px 24px 32px 24px',
@@ -94,7 +94,7 @@ function Photography() {
             pt: 10,
             pb: 8,
         }}>
-            <Container maxWidth="md">
+            <Container maxWidth="md" sx={{ px: { xs: 3, sm: 3 } }}>
                 <Box sx={{ mb: 1 }}>
                     <Typography sx={{ color: colors.black, fontSize: '2rem', fontWeight: 'bold' }}>
                         Photography
@@ -118,7 +118,7 @@ function Photography() {
                     <Typography sx={sectionHeaderSx}>Gallery</Typography>
                 </Box>
 
-                <Grid container spacing={4}>
+                <Grid container spacing={{ xs: 5, sm: 6 }}>
                     {photos.map((photo, index) => (
                         <Grid size={{ xs: 12, sm: 6 }} key={index}>
                             <PhotoFrame

--- a/src/photography/Photography.js
+++ b/src/photography/Photography.js
@@ -94,7 +94,7 @@ function Photography() {
             pt: 10,
             pb: 8,
         }}>
-            <Container maxWidth="md" sx={{ px: { xs: 3, sm: 3 } }}>
+            <Container maxWidth="md">
                 <Box sx={{ mb: 1 }}>
                     <Typography sx={{ color: colors.black, fontSize: '2rem', fontWeight: 'bold' }}>
                         Photography
@@ -118,17 +118,19 @@ function Photography() {
                     <Typography sx={sectionHeaderSx}>Gallery</Typography>
                 </Box>
 
-                <Grid container spacing={{ xs: 5, sm: 6 }}>
-                    {photos.map((photo, index) => (
-                        <Grid size={{ xs: 12, sm: 6 }} key={index}>
-                            <PhotoFrame
-                                src={photo.src}
-                                alt={photo.alt}
-                                caption={photo.caption}
-                            />
-                        </Grid>
-                    ))}
-                </Grid>
+                <Box sx={{ px: { xs: 1, sm: 0 } }}>
+                    <Grid container spacing={{ xs: 5, sm: 6 }}>
+                        {photos.map((photo, index) => (
+                            <Grid size={{ xs: 12, sm: 6 }} key={index}>
+                                <PhotoFrame
+                                    src={photo.src}
+                                    alt={photo.alt}
+                                    caption={photo.caption}
+                                />
+                            </Grid>
+                        ))}
+                    </Grid>
+                </Box>
             </Container>
         </Box>
     );

--- a/src/photography/Photography.js
+++ b/src/photography/Photography.js
@@ -119,7 +119,7 @@ function Photography() {
                 </Box>
 
                 <Box sx={{ px: { xs: 1, sm: 0 } }}>
-                    <Grid container spacing={{ xs: 5, sm: 6 }}>
+                    <Grid container spacing={{ xs: 5, sm: 6 }} justifyContent="center">
                         {photos.map((photo, index) => (
                             <Grid size={{ xs: 12, sm: 6 }} key={index}>
                                 <PhotoFrame

--- a/src/photography/Photography.js
+++ b/src/photography/Photography.js
@@ -1,0 +1,137 @@
+import React from 'react';
+
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Divider from '@mui/material/Divider';
+import Grid from '@mui/material/Grid';
+import { colors } from '../colors';
+
+const sectionHeaderSx = {
+    color: colors.black,
+    fontWeight: 'bold',
+    fontSize: '1.1rem',
+    letterSpacing: '0.15em',
+    textTransform: 'uppercase',
+    mb: 2,
+};
+
+const dividerSx = {
+    borderColor: colors.black,
+    opacity: 0.2,
+    my: 4,
+};
+
+const captionSx = {
+    color: colors.black,
+    opacity: 0.7,
+    fontSize: '0.8rem',
+    mt: 1.5,
+    textAlign: 'center',
+    lineHeight: 1.5,
+};
+
+const frameSx = {
+    backgroundColor: colors.white,
+    border: `3px solid ${colors.black}`,
+    boxShadow: '6px 6px 20px rgba(0, 0, 0, 0.3), 2px 2px 6px rgba(0, 0, 0, 0.15)',
+    // Matte padding: more on bottom like a real gallery matte
+    padding: '24px 24px 32px 24px',
+};
+
+const photos = [
+    {
+        src: '/photos/placeholder-1.jpg',
+        alt: 'Untitled',
+        caption: 'Untitled',
+    },
+    {
+        src: '/photos/placeholder-2.jpg',
+        alt: 'Untitled',
+        caption: 'Untitled',
+    },
+    {
+        src: '/photos/placeholder-3.jpg',
+        alt: 'Untitled',
+        caption: 'Untitled',
+    },
+    {
+        src: '/photos/placeholder-4.jpg',
+        alt: 'Untitled',
+        caption: 'Untitled',
+    },
+];
+
+function PhotoFrame({ src, alt, caption }) {
+    return (
+        <Box>
+            <Box sx={frameSx}>
+                <Box
+                    component="img"
+                    src={src}
+                    alt={alt}
+                    sx={{
+                        width: '100%',
+                        height: 'auto',
+                        display: 'block',
+                        backgroundColor: '#e0e0e0',
+                        // Fallback aspect ratio for missing images
+                        minHeight: '200px',
+                    }}
+                />
+            </Box>
+            <Typography sx={captionSx}>{caption}</Typography>
+        </Box>
+    );
+}
+
+function Photography() {
+    return (
+        <Box sx={{
+            backgroundColor: colors.white,
+            minHeight: '100vh',
+            width: 1,
+            pt: 10,
+            pb: 8,
+        }}>
+            <Container maxWidth="md">
+                <Box sx={{ mb: 1 }}>
+                    <Typography sx={{ color: colors.black, fontSize: '2rem', fontWeight: 'bold' }}>
+                        Photography
+                    </Typography>
+                </Box>
+
+                <Box sx={{ mt: 3 }}>
+                    <Typography sx={{ color: colors.black, opacity: 0.85, fontSize: '0.9rem', lineHeight: 1.7 }}>
+                        I shoot analog black and white film. There is something
+                        meditative about the constraints of film — the finite
+                        number of frames, the manual focus, the patience required
+                        in the darkroom. I find the process as rewarding as the
+                        results. Most of what I shoot is 35mm on a Canonet QL17,
+                        developed and scanned at home.
+                    </Typography>
+                </Box>
+
+                <Divider sx={dividerSx} />
+
+                <Box sx={{ mb: 2 }}>
+                    <Typography sx={sectionHeaderSx}>Gallery</Typography>
+                </Box>
+
+                <Grid container spacing={4}>
+                    {photos.map((photo, index) => (
+                        <Grid size={{ xs: 12, sm: 6 }} key={index}>
+                            <PhotoFrame
+                                src={photo.src}
+                                alt={photo.alt}
+                                caption={photo.caption}
+                            />
+                        </Grid>
+                    ))}
+                </Grid>
+            </Container>
+        </Box>
+    );
+}
+
+export default Photography;


### PR DESCRIPTION
New /photography route with white background and black text, featuring
a heading section for describing the hobby, a divider, and a two-column
gallery with CSS-based professional gallery frames (black border, drop
shadow, and matte padding). Header gains a camera icon nav link and
supports a dark variant for light-background pages.

https://claude.ai/code/session_01CLscxofhSu19kKa5Q4YnTr