### PR TITLE
Fix header overlap by using solid background color

### DIFF
--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -16,7 +16,20 @@ import Tooltip from '@mui/material/Tooltip';
 
 function Header() {
     return (
-        <AppBar elevation={0} position="fixed" sx={{ backgroundColor: colors.darkBlue }}>
+        <AppBar elevation={0} position="fixed" sx={{
+            backgroundColor: colors.darkBlue,
+            '&::after': {
+                content: '""',
+                position: 'absolute',
+                bottom: 0,
+                left: 0,
+                right: 0,
+                height: '24px',
+                transform: 'translateY(100%)',
+                background: `linear-gradient(to bottom, ${colors.darkBlue}, transparent)`,
+                pointerEvents: 'none',
+            },
+        }}>
             <Toolbar>
                 <Typography
                     variant="h6"

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -16,7 +16,7 @@ import Tooltip from '@mui/material/Tooltip';
 
 function Header() {
     return (
-        <AppBar elevation={0} position="fixed" color="transparent">
+        <AppBar elevation={0} position="fixed" sx={{ backgroundColor: colors.darkBlue }}>
             <Toolbar>
                 <Typography
                     variant="h6"


### PR DESCRIPTION
The AppBar was using color="transparent", causing page content to
show through the fixed header when scrolling. Changed to use the
dark blue background color for a solid header.

https://claude.ai/code/session_01WvXDPdFLoxrg1yY84EzVTK