### PR TITLE
Fix broken Open Graph preview link metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,9 +22,10 @@
     </script>
     <meta name="viewport" content="initial-scale=1, width=device-width" />
     <meta property="og:title" content="Mark Spicer" />
-    <meta property="og:type" content="image/png" />
+    <meta property="og:type" content="website" />
     <meta property="og:url" content="https://markspicer.me" />
     <meta property="og:image" content="/social.png" />
+    <meta property="og:description" content="My personal website ✨ If you're reading this, you should definitely check it out 👀" />
   </head>
   <body>
     <div id="root">

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <meta property="og:title" content="Mark Spicer" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://markspicer.me" />
-    <meta property="og:image" content="/social.png" />
+    <meta property="og:image" content="https://markspicer.me/social.png" />
     <meta property="og:description" content="My personal website ✨ If you're reading this, you should definitely check it out 👀" />
   </head>
   <body>


### PR DESCRIPTION
Set og:type to "website" (was incorrectly "image/png") and add
og:description so the description text appears in link previews.

https://claude.ai/code/session_0162peaTub2qhWZNzK7KqJjd