### PR TITLE
Fix social sharing preview

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_SITE_URL=https://markspicer.me

--- a/index.html
+++ b/index.html
@@ -22,9 +22,14 @@
     </script>
     <meta name="viewport" content="initial-scale=1, width=device-width" />
     <meta property="og:title" content="Mark Spicer" />
-    <meta property="og:type" content="image/png" />
+    <meta property="og:description" content="My personal website ✨ If you're reading this, you should definitely check it out 👀" />
+    <meta property="og:type" content="website" />
     <meta property="og:url" content="https://markspicer.me" />
-    <meta property="og:image" content="/social.png" />
+    <meta property="og:image" content="%VITE_SITE_URL%/social.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Mark Spicer" />
+    <meta name="twitter:description" content="My personal website ✨ If you're reading this, you should definitely check it out 👀" />
+    <meta name="twitter:image" content="%VITE_SITE_URL%/social.png" />
   </head>
   <body>
     <div id="root">


### PR DESCRIPTION
## Summary
- Fix OG meta tags broken during CRA to Vite migration: use absolute URL for `og:image`, correct `og:type` to `website`, add missing `og:description`
- Add Twitter Card meta tags for proper previews on X/Twitter
- Use `VITE_SITE_URL` env var so Netlify preview deploys get correct URLs via `DEPLOY_PRIME_URL`

## Test plan
- [ ] Verify production build replaces `%VITE_SITE_URL%` in meta tags
- [ ] Test social preview with https://www.opengraph.xyz/ after deploy
- [ ] Update Netlify build command to: `VITE_SITE_URL=$DEPLOY_PRIME_URL bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)