### PR TITLE
Use DEPLOY_PRIME_URL for social preview URLs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "bun run build"
+  command = "VITE_SITE_URL=$DEPLOY_PRIME_URL bun run build"
   publish = "build"
 
 [build.environment]


### PR DESCRIPTION
## Summary
- Set `VITE_SITE_URL` from Netlify's `DEPLOY_PRIME_URL` in the build command so `og:image` URLs resolve correctly in both production and deploy preview environments

## Test plan
- [ ] Verify deploy preview has correct og:image URL pointing to the preview domain
- [ ] Verify production deploy has correct og:image URL pointing to markspicer.me

🤖 Generated with [Claude Code](https://claude.com/claude-code)