### PR TITLE
Remove emojis from OG description meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,13 +22,13 @@
     </script>
     <meta name="viewport" content="initial-scale=1, width=device-width" />
     <meta property="og:title" content="Mark Spicer" />
-    <meta property="og:description" content="My personal website ✨ If you're reading this, you should definitely check it out 👀" />
+    <meta property="og:description" content="My personal website. If you're reading this, you should definitely check it out." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://markspicer.me" />
     <meta property="og:image" content="%VITE_SITE_URL%/social.png" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Mark Spicer" />
-    <meta name="twitter:description" content="My personal website ✨ If you're reading this, you should definitely check it out 👀" />
+    <meta name="twitter:description" content="My personal website. If you're reading this, you should definitely check it out." />
     <meta name="twitter:image" content="%VITE_SITE_URL%/social.png" />
   </head>
   <body>


### PR DESCRIPTION
## Summary
- Remove emojis from `og:description` and `twitter:description` to test if they cause some platforms to skip the description in social previews
- Keeps emojis in the regular `<meta name="description">` tag

## Test plan
- [ ] Check deploy preview on https://www.opengraph.xyz/ to see if description now appears on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)