### PR TITLE
Fix mobile touch scrolling on homepage canvas

### DIFF
--- a/src/generative/Generative.jsx
+++ b/src/generative/Generative.jsx
@@ -43,7 +43,6 @@ function Generative() {
                 const height = containerRef.current.clientHeight * 0.8;
                 const cnv = p5.createCanvas(width, height);
                 cnv.parent(canvasParentRef);
-
                 p5.stroke(169, 251, 215);
                 p5.strokeWeight(2);
                 p5.frameRate(30);
@@ -85,6 +84,10 @@ function Generative() {
                     p5.endShape();
                 }
             };
+
+            // Allow touch scrolling past the canvas
+            p5.touchStarted = () => true;
+            p5.touchMoved = () => true;
 
             p5.windowResized = () => {
                 const width = containerRef.current.clientWidth;

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,10 @@ h1 {
   color: #A9FBD7;
 }
 
+canvas {
+  touch-action: pan-y !important;
+}
+
 noscript {
   color: #A9FBD7;
   background-color: #00203F;


### PR DESCRIPTION
## Summary
- Override p5.js `touch-action: none` with global CSS `!important` rule to allow vertical scrolling
- Return `true` from p5 `touchStarted`/`touchMoved` handlers to prevent `preventDefault()` calls

## Test plan
- [ ] Verify touch scrolling works on mobile past the artwork to the about section
- [ ] Verify artwork animation still renders correctly on desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)