### PR TITLE
Fix scroll position not resetting on page navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 
 import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
@@ -118,6 +118,12 @@ function PhotographyPage() {
   );
 }
 
+function ScrollToTop() {
+  const { pathname } = useLocation();
+  useEffect(() => { window.scrollTo(0, 0); }, [pathname]);
+  return null;
+}
+
 function App() {
   useEffect(() => {
     const bannerStyle = `
@@ -158,6 +164,7 @@ function App() {
 
   return (
     <BrowserRouter>
+      <ScrollToTop />
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/resume" element={<ResumePage />} />


### PR DESCRIPTION
## Summary
- Add `ScrollToTop` component that resets scroll to top on route changes
- Fixes issue where navigating between pages preserved the previous scroll position

## Test plan
- [ ] Scroll down on homepage, navigate to resume — page starts at top
- [ ] Scroll down on resume, navigate back to homepage — page starts at top

🤖 Generated with [Claude Code](https://claude.com/claude-code)