### PR TITLE
Fix p5.js console parse error

### DIFF
--- a/src/generative/Generative.jsx
+++ b/src/generative/Generative.jsx
@@ -1,6 +1,7 @@
 
 import React, { useEffect, useRef } from 'react';
 import P5 from 'p5';
+P5.disableFriendlyErrors = true;
 import Box from '@mui/material/Box';
 
 const STEP = 16;


### PR DESCRIPTION
## Summary
- Disable p5.js friendly error system which was trying to parse the minified Vite bundle and throwing a SyntaxError in the console

## Test plan
- [ ] Verify no more `Error parsing code: SyntaxError` in console on production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)